### PR TITLE
Use correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Support Library for Chicago Robotics Simula Boards.
 paragraph=Provides modules for working with the board and its peripherals/sensors.  Now includes behavior tree.
 category=Device Control
 url=https://github.com/ChicagoRobotics/CRC_Simula_Library
-architectures=AVR,Simula
+architectures=avr


### PR DESCRIPTION
The correct architecture value for Arduino/Genuino Mega or Mega 2560 is `avr`. The change to the incorrect `architectures` value in https://github.com/ChicagoRobotics/CRC_Simula_Library/commit/8556ec7480d8746052dbd354c5ca307ba41cc882 causes the example sketch to not appear in the **File > Examples** menu and a warning is shown on compilation:
```
WARNING: library CRC_Simula_Library claims to run on [AVR architecture(s) and may be incompatible with your current board which runs on Simula] architecture(s).
```